### PR TITLE
Change to use minimal pear

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -33,7 +33,7 @@
     },
     "type": "library",
     "require": {
-        "pear/pear": "*"
+        "pear/pear-core-minimal": "*"
     },
     "require-dev": {
         "phpunit/phpunit": "*"


### PR DESCRIPTION
Many, if not most packagist packages use the minimal pear instead of pear/pear, and we are getting "cannot redeclare class pear" because of this.