### PR TITLE
Fixed : Server response is "Message" and not "Ok:"

### DIFF
--- a/Mail/smtp.php
+++ b/Mail/smtp.php
@@ -305,7 +305,7 @@ class Mail_smtp extends Mail {
         $res = $this->_smtp->data($body, $textHeaders);
 		list(,$args) = $this->_smtp->getResponse();
 
-		if (preg_match("/Ok: queued as (.*)/", $args, $queued)) {
+		if (preg_match("/Message queued as (.*)/", $args, $queued)) {
 			$this->queued_as = $queued[1];
 		}
 


### PR DESCRIPTION
I submit the Pull Request, because I think the expected message is rather "Message" than "Ok.", Or we can configure the answer on our server?