### PR TITLE
PHP notice triggered on valid email

### DIFF
--- a/Mail/RFC822.php
+++ b/Mail/RFC822.php
@@ -813,7 +813,7 @@ class Mail_RFC822 {
      */
     protected function _validateDliteral($dliteral)
     {
-        return !preg_match('/(.)[][\x0D\\\\]/', $dliteral, $matches) && $matches[1] != '\\';
+        return !preg_match('/(.)[][\x0D\\\\]/', $dliteral, $matches) && ((! isset($matches[1])) || $matches[1] != '\\');
     }
 
     /**


### PR DESCRIPTION
This will pass, but trigger a php notice... regarding the empty $matches `'jared@[127.0.0.1]` 

This suppresses the notice in the proper way.