### PR TITLE
Change "send" to a static function.

### DIFF
--- a/Mail/mail.php
+++ b/Mail/mail.php
@@ -112,7 +112,7 @@ class Mail_mail extends Mail {
      *               containing a descriptive error message on
      *               failure.
      */
-    public function send($recipients, $headers, $body)
+    public static function send($recipients, $headers, $body)
     {
         if (!is_array($headers)) {
             return PEAR::raiseError('$headers must be an array');


### PR DESCRIPTION
Fixes the "Non-static method PEAR::raiseError() should not be called statically, assuming $this from incompatible context" error for line 162.