### PR TITLE
Establish STARTTLS connection without authentication

### DIFF
--- a/Mail/smtp.php
+++ b/Mail/smtp.php
@@ -205,7 +205,7 @@ class Mail_smtp extends Mail {
      *     host        The server to connect to. Defaults to localhost.
      *     port        The port to connect to. Defaults to 25.
      *     auth        SMTP authentication. Defaults to none.
-     *     starttls    Should STARTTLS connection be used? Defaults to false. PEAR/Net_SMTP >= 1.10.0 required.
+     *     starttls    Should STARTTLS connection be used? No default. PEAR/Net_SMTP >= 1.10.0 required.
      *     username    The username to use for SMTP auth. No default.
      *     password    The password to use for SMTP auth. No default.
      *     localhost   The local hostname / domain. Defaults to localhost.

--- a/Mail/smtp.php
+++ b/Mail/smtp.php
@@ -106,6 +106,18 @@ class Mail_smtp extends Mail {
     var $port = 25;
 
     /**
+     * Should STARTTLS connection be used?
+     *
+     * This value may be set to true or false.
+     *
+     * If the value is set to true, the Net_SMTP package will attempt to use
+     * a STARTTLS encrypted connection.
+     *
+     * @var boolean
+     */
+    var $starttls = false;
+
+    /**
      * Should SMTP authentication be used?
      *
      * This value may be set to true, false or the name of a specific
@@ -207,6 +219,7 @@ class Mail_smtp extends Mail {
         if (isset($params['host'])) $this->host = $params['host'];
         if (isset($params['port'])) $this->port = $params['port'];
         if (isset($params['auth'])) $this->auth = $params['auth'];
+        if (isset($params['starttls'])) $this->starttls = $params['starttls'];
         if (isset($params['username'])) $this->username = $params['username'];
         if (isset($params['password'])) $this->password = $params['password'];
         if (isset($params['localhost'])) $this->localhost = $params['localhost'];
@@ -400,6 +413,16 @@ class Mail_smtp extends Mail {
                                        $res);
                 $this->_smtp->rset();
                 return PEAR::raiseError($error, PEAR_MAIL_SMTP_ERROR_AUTH);
+            }
+        }
+        
+        /* Attempt to establishe a TLS encrypted connection. */
+        if ($this->starttls && $this->auth === False) {
+            $starttls = $this->_smtp->starttls();
+            if(PEAR::isError($starttls)){
+                return PEAR::raiseError($starttls);
+            } elseif($starttls === False){
+                return PEAR::raiseError('STARTTLS failed');
             }
         }
 

--- a/Mail/smtp.php
+++ b/Mail/smtp.php
@@ -113,11 +113,16 @@ class Mail_smtp extends Mail {
      * If the value is set to true, the Net_SMTP package will attempt to use
      * a STARTTLS encrypted connection.
      * 
+     * If the value is set to false, the Net_SMTP package will avoid
+     * a STARTTLS encrypted connection.
+     * 
+     * NULL indicates only STARTTLS if $auth is set.
+     * 
      * PEAR/Net_SMTP >= 1.10.0 required.
      *
      * @var boolean
      */
-    var $starttls = false;
+    var $starttls = null;
 
     /**
      * Should SMTP authentication be used?
@@ -408,10 +413,13 @@ class Mail_smtp extends Mail {
         /* Attempt to authenticate if authentication has been enabled. */
         if ($this->auth) {
             $method = is_string($this->auth) ? $this->auth : '';
+            
+            $tls = $this->starttls === false ? false : true;
 
             if (PEAR::isError($res = $this->_smtp->auth($this->username,
                                                         $this->password,
-                                                        $method))) {
+                                                        $method,
+                                                        $tls))) {
                 $error = $this->_error("$method authentication failure",
                                        $res);
                 $this->_smtp->rset();

--- a/Mail/smtp.php
+++ b/Mail/smtp.php
@@ -6,7 +6,7 @@
  *
  * LICENSE:
  *
- * Copyright (c) 2010-2017, Chuck Hagenbuch & Jon Parise
+ * Copyright (c) 2010-2021, Chuck Hagenbuch & Jon Parise
  * All rights reserved.
  *
  * Redistribution and use in source and binary forms, with or without
@@ -40,7 +40,7 @@
  * @package     HTTP_Request
  * @author      Jon Parise <jon@php.net> 
  * @author      Chuck Hagenbuch <chuck@horde.org>
- * @copyright   2010-2017 Chuck Hagenbuch
+ * @copyright   2010-2021 Chuck Hagenbuch
  * @license     http://opensource.org/licenses/BSD-3-Clause New BSD License
  * @version     CVS: $Id$
  * @link        http://pear.php.net/package/Mail/
@@ -112,6 +112,8 @@ class Mail_smtp extends Mail {
      *
      * If the value is set to true, the Net_SMTP package will attempt to use
      * a STARTTLS encrypted connection.
+     * 
+     * PEAR/Net_SMTP >= 1.10.0 required.
      *
      * @var boolean
      */
@@ -197,7 +199,8 @@ class Mail_smtp extends Mail {
      * passed in. It looks for the following parameters:
      *     host        The server to connect to. Defaults to localhost.
      *     port        The port to connect to. Defaults to 25.
-     *     auth        SMTP authentication.  Defaults to none.
+     *     auth        SMTP authentication. Defaults to none.
+     *     starttls    Should STARTTLS connection be used? Defaults to false. PEAR/Net_SMTP >= 1.10.0 required.
      *     username    The username to use for SMTP auth. No default.
      *     password    The password to use for SMTP auth. No default.
      *     localhost   The local hostname / domain. Defaults to localhost.
@@ -416,12 +419,12 @@ class Mail_smtp extends Mail {
             }
         }
         
-        /* Attempt to establishe a TLS encrypted connection. */
-        if ($this->starttls && $this->auth === False) {
+        /* Attempt to establish a TLS encrypted connection. PEAR/Net_SMTP >= 1.10.0 required. */
+        if ($this->starttls && !$this->auth) {
             $starttls = $this->_smtp->starttls();
-            if(PEAR::isError($starttls)){
+            if (PEAR::isError($starttls)) {
                 return PEAR::raiseError($starttls);
-            } elseif($starttls === False){
+            } elseif ($starttls === false) {
                 return PEAR::raiseError('STARTTLS failed');
             }
         }


### PR DESCRIPTION
For using smartHost, wich authenticates the client via his ip address, to establish the STARTTLS connection without sending credentials.