### PR TITLE
Del: deprecation warnings

### DIFF
--- a/Mail.php
+++ b/Mail.php
@@ -153,7 +153,7 @@ class Mail
         foreach ($headers as $key => $value) {
             $headers[$key] =
                 preg_replace('=((<CR>|<LF>|0x0A/%0A|0x0D/%0D|\\n|\\r)\S).*=i',
-                             null, $value);
+                             '', $value);
         }
     }
 

--- a/Mail/smtp.php
+++ b/Mail/smtp.php
@@ -299,13 +299,13 @@ class Mail_smtp extends Mail {
                                     PEAR_MAIL_SMTP_ERROR_FROM);
         }
 
-        $params = null;
+        $params = '';
         if (!empty($this->_extparams)) {
             foreach ($this->_extparams as $key => $val) {
                 $params .= ' ' . $key . (is_null($val) ? '' : '=' . $val);
             }
         }
-        if (PEAR::isError($res = $this->_smtp->mailFrom($from, ltrim($params ?? '')))) {
+        if (PEAR::isError($res = $this->_smtp->mailFrom($from, ltrim($params)))) {
             $error = $this->_error("Failed to set sender: $from", $res);
             $this->_smtp->rset();
             return PEAR::raiseError($error, PEAR_MAIL_SMTP_ERROR_SENDER);

--- a/Mail/smtp.php
+++ b/Mail/smtp.php
@@ -38,7 +38,7 @@
  *
  * @category    HTTP
  * @package     HTTP_Request
- * @author      Jon Parise <jon@php.net> 
+ * @author      Jon Parise <jon@php.net>
  * @author      Chuck Hagenbuch <chuck@horde.org>
  * @copyright   2010-2017 Chuck Hagenbuch
  * @license     http://opensource.org/licenses/BSD-3-Clause New BSD License
@@ -305,7 +305,7 @@ class Mail_smtp extends Mail {
                 $params .= ' ' . $key . (is_null($val) ? '' : '=' . $val);
             }
         }
-        if (PEAR::isError($res = $this->_smtp->mailFrom($from, ltrim($params)))) {
+        if (PEAR::isError($res = $this->_smtp->mailFrom($from, ltrim($params ?? '')))) {
             $error = $this->_error("Failed to set sender: $from", $res);
             $this->_smtp->rset();
             return PEAR::raiseError($error, PEAR_MAIL_SMTP_ERROR_SENDER);


### PR DESCRIPTION
In PHP 8.1 some standard function will report E_DEPRECATED warnings when you provide `null` values.
This PR removes 2 E_DEPRECATED warnings.