### PR TITLE
Do not use parseAddressList statically

### DIFF
--- a/Mail/RFC822.php
+++ b/Mail/RFC822.php
@@ -60,7 +60,8 @@
  * How do I use it?
  *
  * $address_string = 'My Group: "Richard" <richard@localhost> (A comment), ted@example.com (Ted Bloggs), Barney;';
- * $structure = Mail_RFC822::parseAddressList($address_string, 'example.com', true)
+ * $parser = new Mail_RFC822();
+ * $structure = $parser->parseAddressList($address_string, 'example.com', true);
  * print_r($structure);
  *
  * @author  Richard Heyes <richard@phpguru.org>
@@ -172,11 +173,6 @@ class Mail_RFC822 {
      */
     public function parseAddressList($address = null, $default_domain = null, $nest_groups = null, $validate = null, $limit = null)
     {
-        if (!isset($this) || !isset($this->mailRFC822)) {
-            $obj = new Mail_RFC822($address, $default_domain, $nest_groups, $validate, $limit);
-            return $obj->parseAddressList();
-        }
-
         if (isset($address))        $this->address        = $address;
         if (isset($default_domain)) $this->default_domain = $default_domain;
         if (isset($nest_groups))    $this->nestGroups     = $nest_groups;

--- a/Mail/RFC822.php
+++ b/Mail/RFC822.php
@@ -173,6 +173,15 @@ class Mail_RFC822 {
      */
     public function parseAddressList($address = null, $default_domain = null, $nest_groups = null, $validate = null, $limit = null)
     {
+      if (version_compare(PHP_VERSION, '8.0.0', '<')) {
+          if (!isset($this) || !isset($this->mailRFC822)) {
+              $warn = "Calling non-static methods statically is no longer supported since PHP 8";
+              trigger_error($warn, E_USER_NOTICE);
+              $obj = new Mail_RFC822($address, $default_domain, $nest_groups, $validate, $limit);
+              return $obj->parseAddressList();
+          }
+      }
+
         if (isset($address))        $this->address        = $address;
         if (isset($default_domain)) $this->default_domain = $default_domain;
         if (isset($nest_groups))    $this->nestGroups     = $nest_groups;

--- a/tests/9137.phpt
+++ b/tests/9137.phpt
@@ -18,7 +18,8 @@ for ($i = 0; $i < count($addresses); $i++) {
     $address = "\"" . addslashes($addresses[$i]['name']) . "\" ".
         "<".$addresses[$i]['email'].">";
 
-    $parsedAddresses = Mail_RFC822::parseAddressList($address);
+    $parser = new Mail_RFC822();
+    $parsedAddresses = $parser->parseAddressList($address);
     if (is_a($parsedAddresses, 'PEAR_Error')) {
         echo $address." :: Failed to validate\n";
     } else {

--- a/tests/9137_2.phpt
+++ b/tests/9137_2.phpt
@@ -18,7 +18,8 @@ $addresses = array(
 for ($i = 0; $i < count($addresses); $i++) {
     // construct the address
     $address = $addresses[$i]['raw'];
-    $parsedAddresses = Mail_RFC822::parseAddressList($address);
+    $parser = new Mail_RFC822();
+    $parsedAddresses = $parser->parseAddressList($address);
     if (PEAR::isError($parsedAddresses)) {
         echo $address." :: Failed to validate\n";
     } else {

--- a/tests/bug17178.phpt
+++ b/tests/bug17178.phpt
@@ -4,7 +4,8 @@ Mail_RFC822::parseAddressList does not accept RFC-valid group syntax
 <?php
 require "Mail/RFC822.php";
 
-var_dump(Mail_RFC822::parseAddressList("empty-group:;","invalid",false,false)); 
+$parser = new Mail_RFC822();
+var_dump($parser->parseAddressList("empty-group:;","invalid",false,false));
 
 --EXPECT--
 array(0) {

--- a/tests/bug17317.phpt
+++ b/tests/bug17317.phpt
@@ -4,9 +4,10 @@ Mail_RFC822::parseAddressList invalid periods in mail address
 <?php
 require "Mail/RFC822.php";
 
-$result[] = Mail_RFC822::parseAddressList('.name@example.com');
-$result[] = Mail_RFC822::parseAddressList('name.@example.com');
-$result[] = Mail_RFC822::parseAddressList('name..name@example.com');
+$parser = new Mail_RFC822();
+$result[] = $parser->parseAddressList('.name@example.com');
+$result[] = $parser->parseAddressList('name.@example.com');
+$result[] = $parser->parseAddressList('name..name@example.com');
 
 foreach ($result as $r) {
     if (is_a($r, 'PEAR_Error')) {

--- a/tests/validateQuotedString.phpt
+++ b/tests/validateQuotedString.phpt
@@ -5,7 +5,8 @@ Mail_RFC822::parseAddressList simple tests
 require_once 'Mail/RFC822.php';
 $address_string = '"Joe Doe \(from Somewhere\)" <doe@example.com>, postmaster@example.com, root';
 
-$address_array = Mail_RFC822::parseAddressList($address_string, "example.com");
+$parser = new Mail_RFC822();
+$address_array = $parser->parseAddressList($address_string, "example.com");
 
 foreach ($address_array as $val) {
     echo "mailbox : " . $val->mailbox . "\n";

--- a/tests/validateQuotedStringWithStatcCalls.phpt
+++ b/tests/validateQuotedStringWithStatcCalls.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Mail_RFC822::parseAddressList simple tests with static calls
+--SKIPIF--
+<?php if (version_compare(PHP_VERSION, '8.0.0', '>=')) die("Skipped: PHP >=8 does not support static calls to non-static methods."); ?>
+--FILE--
+<?php
+require_once 'Mail/RFC822.php';
+$address_string = '"Joe Doe \(from Somewhere\)" <doe@example.com>, postmaster@example.com, root';
+
+$address_array = Mail_RFC822::parseAddressList($address_string, "example.com");
+
+foreach ($address_array as $val) {
+    echo "mailbox : " . $val->mailbox . "\n";
+    echo "host    : " . $val->host . "\n";
+    echo "personal: " . $val->personal . "\n";
+}
+--EXPECTF--
+Notice: Calling non-static methods statically is no longer supported since PHP 8 in %sRFC822.php on line %d
+mailbox : doe
+host    : example.com
+personal: "Joe Doe \(from Somewhere\)"
+mailbox : postmaster
+host    : example.com
+personal: 
+mailbox : root
+host    : example.com
+personal: 


### PR DESCRIPTION
Since PHP 8, calling non-static methods statically results in fatal
errors.

This change was introduced in the php-mail package in Ubuntu to support
PHP 8 by Bryce Harrington.

Signed-off-by: Athos Ribeiro <athoscribeiro@gmail.com>