### PR TITLE
Fix whitespace removal from adressess

### DIFF
--- a/Mail/RFC822.php
+++ b/Mail/RFC822.php
@@ -486,7 +486,7 @@ class Mail_RFC822 {
         }
 
         // Trim the whitespace from all of the address strings.
-        array_map('trim', $addresses);
+        $addresses = array_map('trim', $addresses);
 
         // Validate each mailbox.
         // Format could be one of: name <geezer@domain.com>


### PR DESCRIPTION
[`array_map()`](https://www.php.net/manual/en/function.array-map.php) returns new array as result, it does not work on the passed array in-place. This is true for PHP versions back to 4.3.0 (https://3v4l.org/jPE80), which is lower than the least PHP version pear/Mail supports.

The array_map call was introduced a long while ago and probably never worked correctly since then.